### PR TITLE
chore(ci): add degraded mode bypass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,19 @@ jobs:
           cache: npm
           check-latest: true
 
+      - name: Degraded mode check
+        id: degraded
+        run: |
+          if [ "${{ secrets.DEGRADED_CI }}" = "true" ]; then
+            echo "degraded=true" >> $GITHUB_OUTPUT
+            echo "⚠️ CI está em modo degradado: instalação/build desativados."
+          else
+            echo "degraded=false" >> $GITHUB_OUTPUT
+            echo "CI em modo normal."
+          fi
+
       - name: Harden npm config
+        if: steps.degraded.outputs.degraded == 'false'
         run: |
           echo "registry=https://registry.npmjs.org/" > .npmrc
           npm config set fetch-retries 5
@@ -36,6 +48,7 @@ jobs:
           NODE_OPTIONS: --dns-result-order=ipv4first
 
       - name: Install dependencies (retry + registry fallback, include dev)
+        if: steps.degraded.outputs.degraded == 'false'
         shell: bash
         env:
           NPM_CONFIG_PRODUCTION: "false"
@@ -80,6 +93,7 @@ jobs:
           test -f node_modules/vite/bin/vite.js && echo "vite bin OK" || echo "vite bin MISSING"
 
       - name: Diagnose install
+        if: steps.degraded.outputs.degraded == 'false'
         shell: bash
         run: |
           echo "----- NODE / NPM VERSIONS -----"
@@ -103,6 +117,7 @@ jobs:
           npm ls --depth=0 || true
 
       - name: Ensure Vite present (retry if missing)
+        if: steps.degraded.outputs.degraded == 'false'
         shell: bash
         env:
           NPM_CONFIG_PRODUCTION: "false"
@@ -126,14 +141,18 @@ jobs:
           else
             echo "⚠️ vite local ausente; build tentará npx como último recurso"
           fi
+
       - name: Typecheck
+        if: steps.degraded.outputs.degraded == 'false'
         run: npx tsc --noEmit
 
       - name: Lint (non-blocking)
+        if: steps.degraded.outputs.degraded == 'false'
         continue-on-error: true
         run: npm run lint
 
       - name: Build
+        if: steps.degraded.outputs.degraded == 'false'
         shell: bash
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'dummy-url' }}
@@ -145,6 +164,12 @@ jobs:
             echo "⚠️ vite local não encontrado; tentando npx com registry atual..."
             npx --yes vite@^5 build
           fi
+
+      - name: Degraded success marker
+        if: steps.degraded.outputs.degraded == 'true'
+        run: |
+          echo "✅ CI aprovado em modo degradado (sem instalar/buildar por falta de rede)."
+          echo "Quando a rede voltar, desative o secret DEGRADED_CI para restaurar o fluxo completo."
 
   e2e-smoke:
     runs-on: ubuntu-latest
@@ -159,7 +184,19 @@ jobs:
           cache: npm
           check-latest: true
 
+      - name: Degraded mode check
+        id: degraded
+        run: |
+          if [ "${{ secrets.DEGRADED_CI }}" = "true" ]; then
+            echo "degraded=true" >> $GITHUB_OUTPUT
+            echo "⚠️ CI está em modo degradado: instalação/build desativados."
+          else
+            echo "degraded=false" >> $GITHUB_OUTPUT
+            echo "CI em modo normal."
+          fi
+
       - name: Harden npm config
+        if: steps.degraded.outputs.degraded == 'false'
         run: |
           echo "registry=https://registry.npmjs.org/" > .npmrc
           npm config set fetch-retries 5
@@ -174,6 +211,7 @@ jobs:
           NODE_OPTIONS: --dns-result-order=ipv4first
 
       - name: Install dependencies (retry + registry fallback, include dev)
+        if: steps.degraded.outputs.degraded == 'false'
         shell: bash
         env:
           NPM_CONFIG_PRODUCTION: "false"
@@ -218,6 +256,7 @@ jobs:
           test -f node_modules/vite/bin/vite.js && echo "vite bin OK" || echo "vite bin MISSING"
 
       - name: Diagnose install
+        if: steps.degraded.outputs.degraded == 'false'
         shell: bash
         run: |
           echo "----- NODE / NPM VERSIONS -----"
@@ -239,7 +278,9 @@ jobs:
           fi
           echo "----- TOP LEVEL LIST -----"
           npm ls --depth=0 || true
+
       - name: Ensure Vite present (retry if missing)
+        if: steps.degraded.outputs.degraded == 'false'
         shell: bash
         env:
           NPM_CONFIG_PRODUCTION: "false"
@@ -263,10 +304,13 @@ jobs:
           else
             echo "⚠️ vite local ausente; build tentará npx como último recurso"
           fi
+
       - name: Install Playwright
+        if: steps.degraded.outputs.degraded == 'false'
         run: npx playwright install --with-deps chromium
 
       - name: Build
+        if: steps.degraded.outputs.degraded == 'false'
         shell: bash
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'dummy-url' }}
@@ -280,19 +324,28 @@ jobs:
           fi
 
       - name: Start preview server
+        if: steps.degraded.outputs.degraded == 'false'
         run: npm run preview &
 
       - name: Wait for server
+        if: steps.degraded.outputs.degraded == 'false'
         run: npx wait-on http://localhost:4173 --timeout 60000
 
       - name: Run E2E smoke tests
+        if: steps.degraded.outputs.degraded == 'false'
         run: npx playwright test
         continue-on-error: true
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
-        if: always()
+        if: steps.degraded.outputs.degraded == 'false' && always()
         with:
           name: e2e-results
           path: playwright-report/
           retention-days: 7
+
+      - name: Degraded success marker
+        if: steps.degraded.outputs.degraded == 'true'
+        run: |
+          echo "✅ CI aprovado em modo degradado (sem instalar/buildar por falta de rede)."
+          echo "Quando a rede voltar, desative o secret DEGRADED_CI para restaurar o fluxo completo."

--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## CI Degradado (bypass temporário)
+
+- Defina o secret de repositório **DEGRADED_CI=true** para que o pipeline **pule instalação/build/test** e marque os jobs como sucesso controlado.
+- Use somente quando houver bloqueio de rede (403 nos registries).
+- Para restaurar o fluxo normal, **remova** o secret ou defina `DEGRADED_CI=false`.


### PR DESCRIPTION
## Summary
- allow skipping install/build/test via `DEGRADED_CI` secret in CI workflow
- document degraded CI flag in README

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68a881a6b02c8323a30354d9f6d110db