### PR TITLE
chore(ci): add lockfile regeneration workflow

### DIFF
--- a/.github/workflows/regenerate-lockfile.yml
+++ b/.github/workflows/regenerate-lockfile.yml
@@ -1,0 +1,92 @@
+name: Regenerate Lockfile
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write  # permite commit via GITHUB_TOKEN
+
+jobs:
+  regen-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          check-latest: true
+
+      - name: Harden npm config
+        run: |
+          echo "registry=https://registry.npmjs.org/" > .npmrc
+          npm config set fetch-retries 5
+          npm config set fetch-retry-maxtimeout 120000
+          npm config set fetch-retry-mintimeout 20000
+          npm config set prefer-online true
+          npm config set legacy-peer-deps true
+          npm cache clean --force
+          node -v
+          npm -v
+          npm config list
+
+      - name: Clean previous installs
+        run: rm -rf node_modules package-lock.json
+
+      - name: Install (retry + fallback registry)
+        shell: bash
+        run: |
+          set -e
+          attempt() { npm install --include=dev --no-audit --no-fund; }
+          fallback_registry() {
+            echo "⚠️ switching registry to npmmirror fallback..."
+            npm config set registry https://registry.npmmirror.com
+            npm cache clean --force || true
+          }
+          for i in 1 2 3; do
+            if attempt; then
+              echo "Dependencies installed on attempt $i (npmjs)"; break
+            fi
+            echo "npm install attempt $i failed on npmjs; retry in $((i*10))s"
+            npm cache clean --force || true
+            sleep $((i*10))
+            if [ "$i" -eq 3 ]; then
+              fallback_registry
+            fi
+          done
+          if [ "$(npm config get registry)" = "https://registry.npmmirror.com" ]; then
+            for j in 1 2; do
+              if attempt; then
+                echo "Dependencies installed on attempt $j (npmmirror)"; break
+              fi
+              echo "npm install attempt $j failed on npmmirror; retry in $((j*10))s"
+              npm cache clean --force || true
+              sleep $((j*10))
+              if [ "$j" -eq 2 ]; then
+                echo "Final attempt failed."; exit 1
+              fi
+            done
+          fi
+          test -f node_modules/vite/bin/vite.js && echo "vite OK" || echo "vite MISSING (ok para este workflow)"
+
+      - name: Commit lockfile if changed
+        shell: bash
+        env:
+          GIT_AUTHOR_NAME: ci-bot
+          GIT_AUTHOR_EMAIL: actions@users.noreply.github.com
+          GIT_COMMITTER_NAME: ci-bot
+          GIT_COMMITTER_EMAIL: actions@users.noreply.github.com
+        run: |
+          if [ -f package-lock.json ]; then
+            if ! git diff --quiet package-lock.json; then
+              git add package-lock.json
+              git commit -m "chore(ci): regenerate package-lock.json"
+              git push
+              echo "Lockfile updated & pushed."
+            else
+              echo "No changes in package-lock.json."
+            fi
+          else
+            echo "package-lock.json not found; install likely failed."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add manual workflow to regenerate npm lockfile with retries and fallback registry

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (eslint skipped)


------
https://chatgpt.com/codex/tasks/task_b_68a8bf4fdf308323ab3fe5ccbdc172f5