### PR TITLE
Fix supplier proposal sync table mapping

### DIFF
--- a/src/services/sync/sync.ts
+++ b/src/services/sync/sync.ts
@@ -181,11 +181,29 @@ function transformRecordForSupabase(record: any, entityName: string, userId: str
         created_at: base.created_at,
         updated_at: base.updated_at
       };
-    case 'budgets':
+    case 'budgets': {
+      const projectId = record.projectId || record.project_id;
+      const createdAtISO =
+        record.created_at ||
+        (record.createdAt ? new Date(record.createdAt).toISOString() : new Date().toISOString());
+      const updatedAtISO =
+        record.updated_at ||
+        (record.updatedAt ? new Date(record.updatedAt).toISOString() : new Date().toISOString());
+
       return {
-        ...base,
-        project_id: record.projectId
+        id: record.id,
+        project_id: projectId,
+        supplier: record.supplier,
+        status: record.status ?? 'pending',
+        file_name: record.fileName ?? record.file_name ?? null,
+        file_path: record.filePath ?? record.file_path ?? null,
+        file_size: record.fileSize ?? record.file_size ?? null,
+        uploaded_at: record.uploadedAt ?? record.uploaded_at ?? null,
+        user_id: userId,
+        created_at: createdAtISO,
+        updated_at: updatedAtISO
       };
+    }
     case 'item_versions':
       return {
         id: record.id,
@@ -237,11 +255,22 @@ function transformRecordForLocal(record: any, entityName: string): any {
         _dirty: 0,
         _deleted: 0
       };
-    case 'budgets':
+    case 'budgets': {
+      const fileName = record.file_name ?? (record as any).fileName;
+      const filePath = record.file_path ?? (record as any).filePath;
+      const fileSize = record.file_size ?? (record as any).fileSize;
+      const uploadedAt = record.uploaded_at ?? (record as any).uploadedAt;
+
       return {
         ...base,
-        projectId: record.project_id
+        projectId: record.project_id,
+        fileName,
+        filePath,
+        fileSize,
+        uploadedAt,
+        status: (record.status as ProjectBudget['status']) ?? 'pending'
       };
+    }
     case 'item_versions':
       return {
         id: record.id,
@@ -361,7 +390,7 @@ export async function syncPush(): Promise<LegacySyncMetrics> {
       { name: 'projects', table: 'projects' },
       { name: 'installations', table: 'installations' },
       { name: 'contacts', table: 'contacts' },
-      { name: 'budgets', table: 'budgets' },
+      { name: 'budgets', table: 'supplier_proposals' },
       { name: 'item_versions', table: 'item_versions' },
       { name: 'files', table: 'files' }
     ];
@@ -420,7 +449,7 @@ export async function syncPull(): Promise<LegacySyncMetrics> {
       { name: 'projects', table: 'projects' },
       { name: 'installations', table: 'installations' },
       { name: 'contacts', table: 'contacts' },
-      { name: 'budgets', table: 'budgets' },
+      { name: 'budgets', table: 'supplier_proposals' },
       { name: 'item_versions', table: 'item_versions' },
       { name: 'files', table: 'files' }
     ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,9 +79,17 @@ export interface ProjectBudget {
   project_id?: string;
   projectId?: string; // Legacy field for compatibility
   supplier: string;
-  amount: number;
   status: 'pending' | 'approved' | 'rejected';
   created_at: string;
+  updated_at?: string;
+  fileName?: string;
+  file_name?: string; // Legacy field for compatibility with Supabase payloads
+  filePath?: string;
+  file_path?: string;
+  fileSize?: number;
+  file_size?: number;
+  uploadedAt?: string;
+  uploaded_at?: string;
   // Local timestamp for compatibility
   updatedAt?: number;
   createdAt?: number;


### PR DESCRIPTION
## Summary
- update the sync service to read and write supplier proposals instead of the removed budgets table
- normalize supplier proposal payloads so file metadata fields round-trip correctly during sync
- refresh the ProjectBudget type to reflect the supplier proposal schema

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e532afb8ac8323a3e75539a1520394